### PR TITLE
Update to allow input images in nifti and nrrd format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .vscode
+**/__pycache__
 data/*
 weights/*

--- a/cli/finalize.py
+++ b/cli/finalize.py
@@ -11,8 +11,11 @@ parser.add_argument('--roi', dest='rois', type=str, nargs='+',
                     default=['Ventricle_R', 'Ventricle_L', 'Atrium_R', 'Atrium_L', 'Coronary_Atery_R', 'Coronary_LAD', 'Coronary_Atery_CFLX'],
                     help='define the regions of interest')
 
-parser.add_argument('--input_dir', dest='input_dir', type=str,
-                    help='input patient dicom directory')
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--input_dir', dest='input_dir', type=str,
+                    help='input patient dicom directory (ct scan)')
+group.add_argument('--input_file', dest='input_file', type=str,
+                    help='input file in nrrd or nifti format (ct scan)')
 
 parser.add_argument('--output_dir', dest='output_dir', type=str,
                     help='all outputs go here')
@@ -40,8 +43,8 @@ from ssseg import finalize
 
 # parameter
 rois = args.rois
-input_dir = args.input_dir
+input_path = args.input_dir or args.input_file
 output_dir = args.output_dir
 
 # execute
-finalize.finalize(configs, input_dir, output_dir)
+finalize.finalize(configs, input_path, output_dir)

--- a/cli/prepare.py
+++ b/cli/prepare.py
@@ -5,11 +5,14 @@ import sys
 # arguments
 parser = argparse.ArgumentParser(description='Process some integers.')
 
-parser.add_argument('--input_dir', dest='input_dir', type=str,
-                    help='input patient dicom directory')
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--input_dir', dest='input_dir', type=str,
+                    help='input patient dicom directory (ct scan)')
+group.add_argument('--input_file', dest='input_file', type=str,
+                    help='input file in nrrd or nifti format (ct scan)')
 
 parser.add_argument('--hmask', dest='hmask_file', type=str,
-                    help='nifti file of th eheart mask')
+                    help='nifti file of the heart mask')
 
 parser.add_argument('--output_dir', dest='output_dir', type=str,
                     help='all outputs go here')
@@ -31,11 +34,11 @@ print("> added sys.path:    ", parentdir)
 from ssseg import prepare, loading
 
 # parameter
-input_dir = args.input_dir
+input_path = args.input_dir or args.input_file
 hmask_file = args.hmask_file
 output_dir = args.output_dir
 num_random_ttaugvs = args.num_random_ttaugvs
 
 # execute
 loading.createDirectories(output_dir)
-prepare.prepare(input_dir, hmask_file, output_dir, num_random_ttaugvs)
+prepare.prepare(input_path, hmask_file, output_dir, num_random_ttaugvs)

--- a/ssseg/finalize.py
+++ b/ssseg/finalize.py
@@ -99,13 +99,15 @@ def getPatientCropContext(tio_heart, crop_dim, verbose=True):
     
     return opads
 
-def getOriginalSourcePatient(input_dir):
-    print("loading srcVol from", input_dir)
-    reader = sitk.ImageSeriesReader()
-    dicom_names = reader.GetGDCMSeriesFileNames(input_dir)
-    reader.SetFileNames(dicom_names)
-    srcVol = reader.Execute()
-
+def getOriginalSourcePatient(input_path):
+    print("loading srcVol from", input_path)
+    if os.path.isdir(input_path):
+        reader = sitk.ImageSeriesReader()
+        dicom_names = reader.GetGDCMSeriesFileNames(input_path)
+        reader.SetFileNames(dicom_names)
+        srcVol = reader.Execute()
+    else:
+        srcVol = sitk.ReadImage(input_path)
     return srcVol
 
 def exportVolumeAsNRRD(srcVol, conf3d_pad, filename, th=None):
@@ -146,7 +148,7 @@ def exportVolumeAsNRRD(srcVol, conf3d_pad, filename, th=None):
     # write file, using compression (True)
     sitk.WriteImage(itkVolRS, filename, True)
 
-def finalize(configs, input_dir, output_dir):
+def finalize(configs, input_path, output_dir):
 
     # extract rois from config keys
     rois = list(configs.keys())
@@ -164,7 +166,7 @@ def finalize(configs, input_dir, output_dir):
     loading.storeFinalResultsForEvaluation(output_dir, roi_orig_confmaps, roi_ttaug_confmaps)
 
     #
-    srcVol = getOriginalSourcePatient(input_dir)
+    srcVol = getOriginalSourcePatient(input_path)
 
     # put in patient context
     for roi in rois:

--- a/ssseg/prepare.py
+++ b/ssseg/prepare.py
@@ -9,15 +9,15 @@ import torchio as tio
 # local imports
 from . import loading
 
-def getSubject(input_dir, hmask_file):
+def getSubject(input_path, hmask_file):
 
     #
-    assert os.path.isdir(input_dir), "input_dir must be a folder containing ct-scan dicom files for one patient"
+    assert os.path.exists(input_path), "input_data must be either a patients ct scan in nrrd or nifti format or a folder containing dicom files of a single patients ct scan"
     assert os.path.isfile(hmask_file), "hmask_file must be a nifti file containing the patients heart mask"
 
     # create subject
     subject = tio.Subject(
-        ct_scan =  tio.ScalarImage(input_dir),  # dicom -> TODO: or better use nifti here too? does it make any difference?
+        ct_scan =  tio.ScalarImage(input_path), # dicom / nifti / nrrd
         Heart = tio.LabelMap(hmask_file)        # nifti
     )
 
@@ -134,7 +134,7 @@ def addTTAug(data, t2subject, num_random_ttaugvs):
         # get inverse transformation
         invaug_xfm = at2subject.get_inverse_transform(ignore_intensity=True)[0]
         assert isinstance(invaug_xfm, tio.transforms.augmentation.spatial.random_affine.Affine), \
-            f"probaply not the inverse affine we're looking for: {type(inverse_affine)}"
+            f"probaply not the inverse affine we're looking for: {type(invaug_xfm)}"
         ttaugs_inv.append(invaug_xfm)
         
         # extract 2d slices
@@ -165,10 +165,10 @@ def addTTAug(data, t2subject, num_random_ttaugvs):
     return ttaugs_inv
 
 
-def prepare(input_dir, hmask_file, output_dir, num_random_ttaugvs=20):
+def prepare(input_path, hmask_file, output_dir, num_random_ttaugvs=20):
 
     # sunject
-    subject = getSubject(input_dir, hmask_file)
+    subject = getSubject(input_path, hmask_file)
 
     # preprocessing
     t1subject, t2subject = preprocessSubject(subject)


### PR DESCRIPTION
Improve pipeline to take nrrd and nifti files as input.
Generally, it is advised to convert dicom data in a controlled manner. This is because the conversion is sometimes tricky and might result in flawed data for some edge cases depending on the tools used. Hence, blindly relying on third-party conversion tools might lead to unexpected behavior and side effects. 

By this update, the `--input_dir` argument, which is used to set the dicom path, can be replaced by an `--input_file` argument to point to an nrrd or nifti file representation of the input image. The pipeline is thereby extended but not modified. The new argument is available in the _preparation_ and _finalization_ steps.